### PR TITLE
Removing internal SDS types from the table

### DIFF
--- a/V1/SDS/SDS_Types.md
+++ b/V1/SDS/SDS_Types.md
@@ -114,18 +114,6 @@ NullableUInt32Enum      | 710
 NullableUInt64          | 112
 NullableUInt64Enum      | 712
 Object                  | 1
-SdsColumn               | 510
-SdsObject               | 512
-SdsStream               | 507
-SdsStreamIndex          | 508
-SdsTable                | 509
-SdsType                 | 501
-SdsTypeProperty         | 502
-SdsValues               | 511
-SdsStreamView           | 503
-SdsStreamViewMap        | 505
-SdsStreamViewMapProperty| 506
-SdsStreamViewProperty   | 504
 SByte                   | 5
 SByteArray              | 205
 SByteEnum               | 605


### PR DESCRIPTION
Per John N.'s guidance, removing the SDS-internal types from a table of supported types from a file in the correct repository. 