### PR TITLE
Quickstart ModbusTCP Data Selection config - typo

### DIFF
--- a/V1/Modbus/ModbusTCPDataSelectionConfiguration_1-0.md
+++ b/V1/Modbus/ModbusTCPDataSelectionConfiguration_1-0.md
@@ -16,7 +16,7 @@ Complete the following to configure Modbus TCP data selection:
 3. Save the file to the device with EDS installed with the name _DataSelection.config.json_.
 4. Use any tool capable of making HTTP requests to execute a POST command with the contents of that file to the following endpoint: `http://localhost:<port_number>/api/v1/configuration/<EDS adapterId>/DataSelection/`.
 
-The following example shows the HTTPS request using curl, which must be run from the same directory where the file is located, and uses the adapter instance created during installation, which is OpcUa1:
+The following example shows the HTTPS request using curl, which must be run from the same directory where the file is located, and uses the adapter instance created during installation, which is Modbus1:
 
     ```bash
     curl -v -d "@DataSelection.config.json" -H "Content-Type: application/json" "http://localhost:5590/api/v1/configuration/Modbus1/DataSelection"

--- a/V1/Modbus/ModbusTCPDataSelectionConfiguration_1-0.md
+++ b/V1/Modbus/ModbusTCPDataSelectionConfiguration_1-0.md
@@ -19,7 +19,7 @@ Complete the following to configure Modbus TCP data selection:
 The following example shows the HTTPS request using curl, which must be run from the same directory where the file is located, and uses the adapter instance created during installation, which is OpcUa1:
 
     ```bash
-    curl -v -d "@DataSelection.config.json" -H "Content-Type: application/json" "http://localhost:5590/api/v1/configuration/OpcUa1/DataSelection"
+    curl -v -d "@DataSelection.config.json" -H "Content-Type: application/json" "http://localhost:5590/api/v1/configuration/Modbus1/DataSelection"
     ```
 
 To see the streams that have been created in EDS storage for the data specified in the configuration, run the following curl script:


### PR DESCRIPTION
The URL for configuring the modbus data sources is incorrect in this quickstart (it referenced the OPCUA1 data source).