### PR TITLE
Update OPCUADataSelectionConfiguration_1-0.md

### DIFF
--- a/V1/OpcUa/OPCUADataSelectionConfiguration_1-0.md
+++ b/V1/OpcUa/OPCUADataSelectionConfiguration_1-0.md
@@ -86,7 +86,7 @@ The following parameters can be used to configure OPC UA data selection:
 | Parameter     | Required | Type | Nullable | Description |
 |---------------|----------|------|----------|-------------|
 | **Selected** | Optional | `Boolean` | No | Use this field to select a measurement to be collected. To select an item, set to true. To remove an item and not collect its data, leave the field empty or set to false. If not configured, the default value is false.|
-| **Name**      | Optional | `string` | Yes |The optional friendly name of the data item collected from the data source. If not configured, the default value will be the stream id. |
+| **Name**      | Required | `string` | Yes |The friendly name of the data item collected from the data source. The field is populated with DisplayName value from OPC UA server when the data selection configuration is populated by the adapter. |
 | **NodeId**    | Required | `string` | Yes | The NodeId of the variable. |
 | **StreamID** | Optional | `string` | Yes | The custom stream ID used to create the streams. If not specified, the OPC UA EDS adapter will generate a default stream ID based on the measurement configuration. A properly configured custom stream ID follows these rules:<br><br>Is not case-sensitive.<br>Can contain spaces.<br>Cannot start with two underscores ("__").<br>Can contain a maximum of 100 characters.<br>Cannot use the following characters: / : ? # [ ] @ ! $ & ' ( ) \ * + , ; = % < > &#124;<br>Cannot start or end with a period.<br>Cannot contain consecutive periods.<br>Cannot consist of only periods.
 

--- a/V1/OpcUa/OPCUADataSelectionConfiguration_1-0.md
+++ b/V1/OpcUa/OPCUADataSelectionConfiguration_1-0.md
@@ -86,7 +86,7 @@ The following parameters can be used to configure OPC UA data selection:
 | Parameter     | Required | Type | Nullable | Description |
 |---------------|----------|------|----------|-------------|
 | **Selected** | Optional | `Boolean` | No | Use this field to select a measurement to be collected. To select an item, set to true. To remove an item and not collect its data, leave the field empty or set to false. If not configured, the default value is false.|
-| **Name**      | Required | `string` | Yes |The friendly name of the data item collected from the data source. The field is populated with DisplayName value from OPC UA server when the data selection configuration is populated by the adapter. |
+| **Name**      | Required | `string` | Yes |The friendly name of the data item collected from the data source. The field is populated with the DisplayName value from the OPC UA server when the data selection configuration is populated by the adapter. |
 | **NodeId**    | Required | `string` | Yes | The NodeId of the variable. |
 | **StreamID** | Optional | `string` | Yes | The custom stream ID used to create the streams. If not specified, the OPC UA EDS adapter will generate a default stream ID based on the measurement configuration. A properly configured custom stream ID follows these rules:<br><br>Is not case-sensitive.<br>Can contain spaces.<br>Cannot start with two underscores ("__").<br>Can contain a maximum of 100 characters.<br>Cannot use the following characters: / : ? # [ ] @ ! $ & ' ( ) \ * + , ; = % < > &#124;<br>Cannot start or end with a period.<br>Cannot contain consecutive periods.<br>Cannot consist of only periods.
 


### PR DESCRIPTION
Hi Tina, this is just a small change to make correct description of the name property for OPC UA EDS adapter. The current description is valid for the released standalone version of the adapter (1.1) but the EDS required name field to be specified. Please feel free to change the wording and reach out.

Thank you,
Zdenek