### PR TITLE
Replaced left and right quotation marks with normal quotation marks

### DIFF
--- a/V1/Troubleshooting/Troubleshooting_1-0.md
+++ b/V1/Troubleshooting/Troubleshooting_1-0.md
@@ -38,8 +38,8 @@ Use debugging information to troubleshoot problems between an OMF application an
 
 Examples of valid strings representing date and time:
 
-    UTC: “yyyy-mm-ddThh:mm:ssZ”
-    Local: “mm-dd-yyyy hh:mm:ss”
+    UTC: "yyyy-mm-ddThh:mm:ssZ"
+    Local: "mm-dd-yyyy hh:mm:ss"
 
 ## Periodic egress
 
@@ -71,8 +71,8 @@ Use debugging information to troubleshoot problems between Edge Data Store and t
 
 Examples of valid strings representing date and time:
 
-    UTC: “yyyy-mm-ddThh:mm:ssZ”
-    Local: “mm-dd-yyyy hh:mm:ss”
+    UTC: "yyyy-mm-ddThh:mm:ssZ"
+    Local: "mm-dd-yyyy hh:mm:ss"
 
 ### Debugging folder/file structure
 


### PR DESCRIPTION
The example strings use “ (Left Double Quotation Mark, U+201C) and ” (Right Double Quotation Mark, U+201D) around them. This is not accepted by the Edge Data Store if saved to a JSON file on Windows Notepad and used on a curl request. I have replaced it with " (Quotation Mark, U+0022).