### PR TITLE
Include ca-certificates package in image

### DIFF
--- a/content/docker/edge-docker.md
+++ b/content/docker/edge-docker.md
@@ -23,7 +23,7 @@ docker build -t edgedatastore .
 ```bash
 FROM ubuntu:18.04
 WORKDIR /
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libicu60 libssl1.0.0
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates libicu60 libssl1.0.0
 ADD ./EdgeDataStore_linux-arm.tar.gz .
 ENTRYPOINT ["./EdgeDataStore_linux-arm/OSIsoft.Data.System.Host"]
 ```
@@ -33,7 +33,7 @@ ENTRYPOINT ["./EdgeDataStore_linux-arm/OSIsoft.Data.System.Host"]
 ```bash
 FROM ubuntu:18.04
 WORKDIR /
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libicu60 libssl1.0.0
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates libicu60 libssl1.0.0
 ADD ./EdgeDataStore_linux-arm64.tar.gz .
 ENTRYPOINT ["./EdgeDataStore_linux-arm64/OSIsoft.Data.System.Host"]
 ```
@@ -43,7 +43,7 @@ ENTRYPOINT ["./EdgeDataStore_linux-arm64/OSIsoft.Data.System.Host"]
 ```bash
 FROM ubuntu:18.04
 WORKDIR /
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends libicu60 libssl1.0.0
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates libicu60 libssl1.0.0
 ADD ./EdgeDataStore_linux-x64.tar.gz .
 ENTRYPOINT ["./EdgeDataStore_linux-x64/OSIsoft.Data.System.Host"]
 ```


### PR DESCRIPTION
Add ca-certificates to list of packages installed during build of docker image. This updates the CA certificates database so SSL errors are not encountered as described in https://dev.azure.com/osieng/engineering/_workitems/edit/156031/