### PR TITLE
Update modbus-quick-start.md

### DIFF
--- a/content/overview/modbus-quick-start.md
+++ b/content/overview/modbus-quick-start.md
@@ -49,7 +49,7 @@ After you create the data source file, select the streams to store in EDS by con
 
    ```json
    [{
-           "Selected": "true",
+           "Selected": true,
            "UnitId": 1,
            "RegisterType": 3,
            "RegisterOffset": 1,
@@ -59,7 +59,7 @@ After you create the data source file, select the streams to store in EDS by con
            "ScanRate": 500
        },
        {
-           "Selected": "true",
+           "Selected": true,
            "UnitId": 1,
            "RegisterType": 3,
            "RegisterOffset": 2,
@@ -69,7 +69,7 @@ After you create the data source file, select the streams to store in EDS by con
            "ScanRate": 500
        },
        {
-           "Selected": "true",
+           "Selected": true,
            "UnitId": 1,
            "RegisterType": 3,
            "RegisterOffset": 3,
@@ -79,7 +79,7 @@ After you create the data source file, select the streams to store in EDS by con
            "ScanRate": 500
        },
        {
-           "Selected": "true",
+           "Selected": true,
            "UnitId": 1,
            "RegisterType": 3,
            "RegisterOffset": 4,
@@ -89,7 +89,7 @@ After you create the data source file, select the streams to store in EDS by con
            "ScanRate": 500
        },
        {
-           "Selected": "true",
+           "Selected": true,
            "UnitId": 1,
            "RegisterType": 3,
            "RegisterOffset": 5,


### PR DESCRIPTION
Hi Phillip,
Can you confirm that this is the change you requested? 

The Selected property in the Data Selection Item config example in the Modbus quick start guide is in quotes. It should not be.

"true" -> true