### PR TITLE
Update the port configuration change procedure

### DIFF
--- a/content/configuration/system-port-configuration.md
+++ b/content/configuration/system-port-configuration.md
@@ -4,38 +4,24 @@ uid: SystemPortConfiguration
 
 # System port configuration
 
-The _System_Port.json_ file specifies the port on which Edge Data Store is listening for REST API calls. The same port is used for configuration and for writing data to OMF and SDS. The default port is 5590. Valid ports are in the range of 1024-65535.
+The _appsettings.json_ file specifies the port on which Edge Data Store is listening for REST API calls. The same port is used for configuration and for writing data to OMF and SDS. The default port is 5590. Valid ports are in the range of 1024-65535. During installation a prompt will be presented where a non-default port can be specified.
 
-## Configure system port
+## Reconfigure system port
 
-Before changing the port, ensure that no other service or application on the device running EDS is using that port because only one application or service can use a port. If you change the port number through the REST API, you must restart EDS.
+Before changing the port, ensure that no other service or application on the device running EDS is using that port because only one application or service can use a port. After reconfiguring the port, EDS must be restarted for the changes to take effect.
 
-To configure the system port, follow these steps:
+To reconfiure the port follow the steps below:
 
-1. Using any text editor, create a JSON file based on the following example and enter the new port number:
+1. Open the _appsettings.json_ file in a text editor. This file can be found in `C:\Program Files\OSIsoft\EdgeDataStore\` or the location specified during installation. On Linux, this file can be found in `/opt/OSIsoft/EdgeDataStore/`
+2. Change the port value to a valid value and save the file.
+3. Restart the Edge Data Store service.
 
-   ```json
-   {
-     "Port": 5590
-   }
-   ```
-
-1. Save the JSON file with the name _EdgePort.json_
-
-1. Run the following script:
-
-    ```bash
-    curl -d "@EdgePort.json" -H "Content-Type: application/json" -X PUT http://localhost:5590/api/v1/configuration/system/port
-    ```
-
-    **Note:** The port number in the script must be the current port number, not the new port number in the file.
-
-1. After the REST command completes, restart EDS for the change to take effect.
-
-## Parameters for system port
-
-The following parameters is used to specify the system port.
-
-| Parameter      | Required    | Type   | Nullable | Description                      |
-| ------------- | --------- | -------- | -------- | ------------------------------- |
-| **Port** | Required | `integer` | No       | The TCP port to bind EDS to. (Range [1024,65535]) Example: 5590 |
+Sample _appsettings.json_ file
+```json
+{
+  "ApplicationSettings": {
+    "Port": 5590,
+    "ApplicationDataDirectory": "EdgeDataStore"
+  }
+}
+```


### PR DESCRIPTION
This change will modify the procedure for updating the port after installation. Previously, there was a REST endpoint that handled this, but that has since been removed and now the process will have to be completed manually.